### PR TITLE
[Feature] Text Extracter for word counting

### DIFF
--- a/docs/developer_note/components/text_extracter.md
+++ b/docs/developer_note/components/text_extracter.md
@@ -1,0 +1,33 @@
+# Text Extracter
+
+## Introduction
+
+In order to count the number of words in a page, we need to extract the pure text content from the Rich Text.
+
+Consider the following situation :arrow_down:
+
+![DSL](https://user-images.githubusercontent.com/10103993/50403170-5e1f8d80-07d7-11e9-91d0-10cfb75fc9da.png)
+
+There are some different markers that we want to trim.
+- HTML Tags `</> &nbsp;`
+- Editor Markers
+  - overstriking `'''overstriking_text'''`
+  - italic `''italic_text''`
+  - Secondary Title `==Title==`
+  - Redirect `#REDIRECT [[text]]`
+  - ...
+- Spaces & Line Break
+
+## Question
+
+- Q: Are there any packages that can be used to count the words ?
+- A: Nope. We are counting both Chinese characters & alphanumeric characters, we can simply use `len()` function in **Python** . However, we need to extract the pure text first.
+
+## Method
+
+- HTML Tags
+  For **HTML** contents, we use **HTMLParser** which is provided natively.
+- Editor Markers
+  For DSL(Domain Specific Language) Markers, we can only replace them one by one using Regular Expression.
+- Spaces & Line break
+  We can remove spaces & Line Break using Regular Expression.

--- a/wikiglass_analyzer/utilities/text_extracter.py
+++ b/wikiglass_analyzer/utilities/text_extracter.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import re
+from html.parser import HTMLParser
+
+"""
+Usage:
+
+text = "<p>Testing</p>\n''hello''\n'''world'''"
+text = TextExtracter.trim(text)
+# text = Testinghelloworld
+"""
+
+class TextExtracter:
+    def __init__(self, text):
+        self.text = text
+    # Trim HTML
+    def trim_html(self):
+        parser = CustomHTMLParser()
+        parser.feed(self.text.strip())
+        self.text =parser.get_text()
+    # Trim Spaces
+    def trim_space(self):
+        self.text = re.sub(r'\s', repl='', string=self.text, count=0, flags=re.M)
+    # Trim DSL
+    def trim_editor_marker(self):
+        # trim overstriking
+        self.text = re.sub(r"'''(.*)'''", repl=lambda m: m.group(1), string=self.text, count=0)
+        # trim italic
+        self.text = re.sub(r"''(.*)''", repl=lambda m: m.group(1), string=self.text, count=0)
+        # trim second-level title
+        self.text = re.sub(r"==(.*)==", repl=lambda m: m.group(1), string=self.text, count=0)
+        # trim timestamp-signature
+        self.text = re.sub(r"--\[\[.*UTC[（）()]{1}", repl='', string=self.text, count=0)
+        # trim REDIRECT
+        self.text = re.sub(r"#REDIRECT \[\[.*\]\]", repl='', string=self.text, count=0)
+        # trim table
+        self.text = re.sub(r'{| class="wikitable"(.*)|}', repl='', string=self.text, count=0, flags=re.M)
+    '''
+    Trim input string
+    @param {string} text
+    @return {string} trimmed text
+    '''
+    @staticmethod
+    def trim(text):
+        e = TextExtracter(text)
+        e.trim_html()
+        e.trim_editor_marker()
+        e.trim_space()
+        return e.text
+
+class CustomHTMLParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.reset()
+        self.fed = []
+    # Process HTML & append text content to @var{fed}
+    def handle_data(self, data):
+        self.fed.append(data)
+    def get_text(self):
+        return ''.join(self.fed)


### PR DESCRIPTION
# 文本清理，用于文本计数

- HTML
- Editor Marker
- Spaces

## Method

目前的富文本编辑主要有
- HTML 格式的字符串
- 加粗斜体等的标记符
- 以及一些奇怪的比如带时间戳的签名等的字符

HTML格式的字符串可以直接用 python 自带的 **HTMLParser** 直接解析然后提取文本
加粗斜体等等的特殊标记符仍然需要我们手动正则匹配替换
最后再把换行符和空格等删除

清理完的文本，可以直接用 ``len`` 函数来对文本进行计数。

![editor](https://user-images.githubusercontent.com/10103993/50403170-5e1f8d80-07d7-11e9-91d0-10cfb75fc9da.png)


## Example
### Before
```html
這是一個測試頁面。
'''加粗'''
''斜体''
<s>删除线</s>

==二级标题==


<gallery>
檔案:圖片.jpg|標題
檔案:圖片.jpg|標題
</gallery>

--[[用戶:Everstar|Everstar]]（[[用戶討論:Everstar|討論]]） 2018年12月24日 (一) 13:18 (UTC)

#REDIRECT [[重新導向]]

<!-- 隱藏評論 -->

[https://www.google.com.hk 谷歌]

<bs:blog />

{| class="wikitable"
|-
! 標題 1
! 標題 2
! 標題 3
|-
| 列 1, 儲存格 1
| 列 1, 儲存格 2
| 列 1, 儲存格 3
|-
| 列 2, 儲存格 1
| 列 2, 儲存格 2
| 列 2, 儲存格 3
|}

<audio style="display: none;" controls="controls"></audio>

<audio style="display: none;" controls="controls"></audio>
```

### After
```
這是一個測試頁面。加粗斜体删除线二级标题檔案:圖片.jpg|標題檔案:圖片.jpg|標題[https://www.google.com.hk谷歌]||-!標題1!標題2!標題3|-|列1,儲存格1|列1,儲存格2|列1,儲存格3|-|列2,儲存格1|列2,儲存格2|列2,儲存格3|
```